### PR TITLE
reverted FRamework submodule commit, and updated .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "FRamework"]
 	path = FRamework
 	url = https://github.com/FRC125/FRamework.git
+	branch = master


### PR DESCRIPTION
We accidentally updated the FRamework submodule to a commit that wasn't on FRamework's master, and it was not needed. Changed .gitmodules to specify master as the default branch.