### PR TITLE
Added turn-toggle implementation in auto for either field side

### DIFF
--- a/src/com/nutrons/steamworks/Drivetrain.java
+++ b/src/com/nutrons/steamworks/Drivetrain.java
@@ -47,6 +47,8 @@ public class Drivetrain implements Subsystem {
   private final Flowable<Boolean> teleHoldHeading;
   private final ConnectableFlowable<Double> currentHeading;
 
+  private volatile double angleMultiplier = 1.0;
+
   /**
    * A drivetrain which uses Arcade Drive.
    *
@@ -58,7 +60,7 @@ public class Drivetrain implements Subsystem {
    */
   public Drivetrain(Flowable<Boolean> teleHoldHeading, Flowable<Double> currentHeading,
                     Flowable<Double> throttle, Flowable<Double> yaw,
-                    LoopSpeedController leftDrive, LoopSpeedController rightDrive) {
+                    LoopSpeedController leftDrive, LoopSpeedController rightDrive, Flowable<Boolean> autoSides) {
     this.currentHeading = currentHeading.publish();
     this.currentHeading.connect();
     this.throttle = throttle.map(deadbandMap(-DEADBAND, DEADBAND, 0.0)).onBackpressureDrop();
@@ -66,6 +68,11 @@ public class Drivetrain implements Subsystem {
     this.leftDrive = leftDrive;
     this.rightDrive = rightDrive;
     this.teleHoldHeading = teleHoldHeading;
+    autoSides.subscribe((v) -> this.angleMultiplier =  v ? 1.0 : -1.0);
+  }
+
+  public Command turnWithRespectToField(double angle, double tolerance) {
+    return this.turn(this.angleMultiplier*angle, tolerance);
   }
 
   /**

--- a/src/com/nutrons/steamworks/RobotBootstrapper.java
+++ b/src/com/nutrons/steamworks/RobotBootstrapper.java
@@ -48,8 +48,11 @@ public class RobotBootstrapper extends Robot {
   private Turret turret;
   private Shooter shooter;
   private RadioBox<Command> box;
+  private RadioBox<Boolean> brain;
   private Feeder feeder;
   private Gearplacer gearplacer;
+
+  private double autoTurnAngle = 85.0; // degrees
 
   /**
    * Converts booleans into streams, and if the boolean is true,
@@ -158,11 +161,13 @@ public class RobotBootstrapper extends Robot {
     rightLeader.setControlMode(ControlMode.MANUAL);
     this.leftLeader.accept(Events.resetPosition(0.0));
     this.rightLeader.accept(Events.resetPosition(0.0));
+
     this.drivetrain = new Drivetrain(driverPad.buttonB(),
         gyro.getGyroReadings().share(),
         driverPad.leftStickY().map(x -> -x),
         driverPad.rightStickX(),
-        leftLeader, rightLeader);
+        leftLeader, rightLeader,
+            this.brain.selected());
     toFlow(() -> leftLeader.position())
         .subscribe(new WpiSmartDashboard().getTextFieldDouble("lpos"));
     toFlow(() -> rightLeader.position())
@@ -181,13 +186,9 @@ public class RobotBootstrapper extends Robot {
     Map<String, Command> autos = new HashMap<String, Command>() {{
       put("intake", RobotBootstrapper.this
           .climbtake.pulse(true).delayFinish(500, TimeUnit.MILLISECONDS));
-      put("boiler; turn left", Command.serial(
+      put("boiler; turn with respect to field position", Command.serial(
           RobotBootstrapper.this.drivetrain.driveDistance(9.5, 1, 10).endsWhen(Flowable.timer(2, TimeUnit.SECONDS), true),
-          RobotBootstrapper.this.drivetrain.turn(-85, 10),
-          RobotBootstrapper.this.drivetrain.driveDistance(4.5, 1, 10).endsWhen(Flowable.timer(2, TimeUnit.SECONDS), true)).then(kpa40));
-      put("boiler; turn right", Command.serial(
-          RobotBootstrapper.this.drivetrain.driveDistance(9.5, 1, 10).endsWhen(Flowable.timer(2, TimeUnit.SECONDS), true),
-          RobotBootstrapper.this.drivetrain.turn(85, 10),
+          RobotBootstrapper.this.drivetrain.turnWithRespectToField(85, 10),
           RobotBootstrapper.this.drivetrain.driveDistance(4.5, 1, 10).endsWhen(Flowable.timer(2, TimeUnit.SECONDS), true)).then(kpa40));
       put("aim & shoot", Command.parallel(RobotBootstrapper.this.shooter.pulse().delayFinish(12, TimeUnit.SECONDS),
           RobotBootstrapper.this.turret.automagicMode().delayFinish(12, TimeUnit.SECONDS),
@@ -199,8 +200,16 @@ public class RobotBootstrapper extends Robot {
     }};
 
     box = new RadioBox<>("auto4", autos, "intake");
+
+    Map<String, Boolean> fieldPosition = new HashMap<String, Boolean>();
+    fieldPosition.put("LEFT", true);
+    fieldPosition.put("RIGHT", false);
+
+    brain = new RadioBox("Field position", fieldPosition, "LEFT");
+
     sm.registerSubsystem(box);
 
     return sm;
   }
+
 }

--- a/src/com/nutrons/steamworks/RobotBootstrapper.java
+++ b/src/com/nutrons/steamworks/RobotBootstrapper.java
@@ -52,7 +52,7 @@ public class RobotBootstrapper extends Robot {
   private Feeder feeder;
   private Gearplacer gearplacer;
 
-  private double autoTurnAngle = 85.0; // degrees
+  private static final double AUTO_TURN_ANGLE = 85.0; // degrees
 
   /**
    * Converts booleans into streams, and if the boolean is true,
@@ -208,6 +208,7 @@ public class RobotBootstrapper extends Robot {
     brain = new RadioBox("Field position", fieldPosition, "LEFT");
 
     sm.registerSubsystem(box);
+    sm.registerSubsystem(brain);
 
     return sm;
   }

--- a/test/com/nutrons/steamworks/TestDriveTime.java
+++ b/test/com/nutrons/steamworks/TestDriveTime.java
@@ -36,7 +36,7 @@ public class TestDriveTime {
             record[1] = -1;
             assertTrue(System.currentTimeMillis() - 2000 < start);
           }
-        });
+        }, Flowable.just(true));
     dt.driveTimeAction(500).execute(true);
     assertTrue(System.currentTimeMillis() - start < 1000);
     Thread.sleep(4000);


### PR DESCRIPTION
Before Merging
==

Check the following subsystems work:

Drivetrain
--

- [ ] Teleop w/ joysticks
- [ ] Hold heading
- [ ] Turn to angle

Shooter
--

- [ ] Shooter motor spins at right speed
- [ ] Feeder runs forward and backwards on buttons
- [ ] Shoot at least one ball

Turret/Vision
--

- [ ] All other subsystems work w/ camera unplugged
- [ ] Turret turns to limit switches w/ manual control
- [X] ~Turns to target w/ vision~

Climbtake
--

- [ ] Intake runs forward
- [ ] Runs backward
- [ ] Climbs

Auto
--

- [ ] At least one auto mode has been run
