### PR TITLE
Added slow turning

### DIFF
--- a/src/com/nutrons/steamworks/RobotBootstrapper.java
+++ b/src/com/nutrons/steamworks/RobotBootstrapper.java
@@ -117,7 +117,7 @@ public class RobotBootstrapper extends Robot {
     this.driverPad.rightBumper().subscribe(System.out::println);
     sm.registerSubsystem(this.climbtake);
     sm.registerSubsystem(new Turret(vision.getAngle(), vision.getState(), hoodMaster,
-        this.operatorPad.leftStickX()));
+        this.operatorPad.leftStickX(), this.operatorPad.buttonA()));
     leftLeader.setControlMode(ControlMode.MANUAL);
     rightLeader.setControlMode(ControlMode.MANUAL);
     this.leftLeader.accept(Events.resetPosition(0.0));

--- a/src/com/nutrons/steamworks/Turret.java
+++ b/src/com/nutrons/steamworks/Turret.java
@@ -29,7 +29,8 @@ public class Turret implements Subsystem {
    * @param master The talon controlling the movement of the turret.
    */
   public Turret(Flowable<Double> angle, Flowable<String> state, Talon master,
-                Flowable<Double> joyControl, Flowable<Boolean> slowDrive) { //TODO: remove joycontrol
+                Flowable<Double> joyControl,
+                Flowable<Boolean> slowDrive) { //TODO: remove joycontrol
     this.angle = angle;
     this.state = state;
     this.hoodMaster = master;

--- a/src/com/nutrons/steamworks/Turret.java
+++ b/src/com/nutrons/steamworks/Turret.java
@@ -20,6 +20,7 @@ public class Turret implements Subsystem {
   private final Flowable<Boolean> revLim;
   private final Flowable<Boolean> fwdLim;
   private final Flowable<Double> joyControl; //TODO: Remoove
+  private final Flowable<Boolean> slowDrive;
 
   /**
    * The Turret System that is used for aiming our shooter.
@@ -28,7 +29,7 @@ public class Turret implements Subsystem {
    * @param master The talon controlling the movement of the turret.
    */
   public Turret(Flowable<Double> angle, Flowable<String> state, Talon master,
-                Flowable<Double> joyControl) { //TODO: remove joycontrol
+                Flowable<Double> joyControl, Flowable<Boolean> slowDrive) { //TODO: remove joycontrol
     this.angle = angle;
     this.state = state;
     this.hoodMaster = master;
@@ -36,6 +37,7 @@ public class Turret implements Subsystem {
     this.revLim = FlowOperators.toFlow(this.hoodMaster::revLimitSwitchClosed);
     this.fwdLim = FlowOperators.toFlow(this.hoodMaster::fwdLimitSwitchClosed);
     this.joyControl = joyControl;
+    this.slowDrive = slowDrive;
   }
 
   @Override
@@ -61,6 +63,7 @@ public class Turret implements Subsystem {
     Flowable<Double> setpoint = this.angle.map(x -> x * MOTOR_ROTATIONS_TO_TURRET_ROTATIONS / 360.0)
         .map(x -> x + hoodMaster.position());
     this.hoodMaster.setPID(PVAL, IVAL, DVAL, FVAL);
+    setpoint.map(x -> slowDrive.map(y -> y ? x * 0.5 : x));
     setpoint.subscribe(x -> Events.setpoint(x).actOn(hoodMaster));
 
     this.angle.subscribe(new WpiSmartDashboard().getTextFieldDouble("angle"));


### PR DESCRIPTION
Added a slow turning mode to the turret where you can hold a button to get a more precise turning of the turret. 

Before Merging
==

Check the following subsystems work:

Drivetrain
--

- [ ] Teleop w/ joysticks
- [ ] Hold heading
- [ ] Turn to angle

Shooter
--

- [ ] Shooter motor spins at right speed
- [ ] Feeder runs forward and backwards on butttons
- [ ] Shoot at least one ball

Turret/Vision
--

- [ ] All other subsystems work w/ camera unplugged
- [ ] Turret turns to limit switches w/ manual control
- [X] ~Turns to target w/ vision~

Climbtake
--

- [ ] Intake runs forward
- [ ] Runs backward
- [ ] Climbs

Auto
--

- [ ] At least one auto mode has been run
